### PR TITLE
Docker: Move apt-get commands to earlier and add apt-get update 

### DIFF
--- a/docker/build/dev.x86_64.dockerfile
+++ b/docker/build/dev.x86_64.dockerfile
@@ -2,6 +2,34 @@ FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu14.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && \
+   apt-get install -y \
+   bc \
+   cppcheck \
+   debconf-utils \
+   doxygen \
+   graphviz \
+   gdb \
+   git \
+   subversion \
+   google-perftools \
+   lcov \
+   libblas-dev \
+   libboost-all-dev \
+   libcurl4-openssl-dev \
+   libfreetype6-dev \
+   liblapack-dev \
+   libpcap-dev \
+   locate \
+   lsof \
+   realpath \
+   shellcheck \
+   vim \
+   v4l-utils \
+   nfs-common \
+   zip && \
+   apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Run installers.
 COPY installers /tmp/installers
 RUN bash /tmp/installers/pre_install.sh
@@ -28,33 +56,6 @@ RUN bash /tmp/installers/install_undistort.sh
 RUN bash /tmp/installers/install_user.sh
 RUN bash /tmp/installers/install_yarn.sh
 RUN bash /tmp/installers/post_install.sh
-
-RUN apt-get install -y \
-   bc \
-   cppcheck \
-   debconf-utils \
-   doxygen \
-   graphviz \
-   gdb \
-   git \
-   subversion \
-   google-perftools \
-   lcov \
-   libblas-dev \
-   libboost-all-dev \
-   libcurl4-openssl-dev \
-   libfreetype6-dev \
-   liblapack-dev \
-   libpcap-dev \
-   locate \
-   lsof \
-   realpath \
-   shellcheck \
-   vim \
-   v4l-utils \
-   nfs-common \
-   zip && \
-   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /apollo
 USER apollo


### PR DESCRIPTION
before the install.

apt-get commands part is more stable than the installer part, which including build
steps,this may could fasten the docker image build process when there are only
installer changed.